### PR TITLE
Feat/auth guard all endpoints

### DIFF
--- a/src/car/car.controller.ts
+++ b/src/car/car.controller.ts
@@ -7,35 +7,42 @@ import {
   Param,
   Delete,
   BadRequestException,
+  UseGuards,
 } from '@nestjs/common';
 import { CarService } from './car.service';
 import { CreateCarDto } from './dto/create-car.dto';
 import { UpdateCarDto } from './dto/update-car.dto';
+import { AuthGuard } from 'src/auth/auth.guard';
 @Controller('cars')
 export class CarController {
   constructor(private readonly carService: CarService) {}
 
+  @UseGuards(AuthGuard)
   @Post()
   create(@Body() createCarDto: CreateCarDto) {
     return this.carService.create(createCarDto);
   }
 
+  @UseGuards(AuthGuard)
   @Get()
   findAll() {
     return this.carService.findAll();
   }
 
+  @UseGuards(AuthGuard)
   @Get(':id')
   findOne(@Param('id') id: string) {
     this.validateSubscriptionId(id);
     return this.carService.findOne(+id);
   }
 
+  @UseGuards(AuthGuard)
   @Get('user/:userId')
   findAllByUserId(@Param('userId') userId: string) {
     return this.carService.findAllByUserId(+userId);
   }
 
+  @UseGuards(AuthGuard)
   @Patch(':id')
   update(@Param('id') id: string, @Body() updateCarDto: UpdateCarDto) {
     this.validateSubscriptionId(id);
@@ -48,6 +55,7 @@ export class CarController {
     }
   }
 
+  @UseGuards(AuthGuard)
   @Delete(':id')
   remove(@Param('id') id: string) {
     this.validateSubscriptionId(id);

--- a/src/event/event.controller.ts
+++ b/src/event/event.controller.ts
@@ -9,31 +9,37 @@ import {
   BadRequestException,
   Query,
   ParseIntPipe,
+  UseGuards,
 } from '@nestjs/common';
 import { EventService } from './event.service';
 import { CreateEventDto } from './dto/create-event.dto';
 import { UpdateEventDto } from './dto/update-event.dto';
+import { AuthGuard } from 'src/auth/auth.guard';
 
 @Controller('events')
 export class EventController {
   constructor(private readonly eventService: EventService) {}
 
+  @UseGuards(AuthGuard)
   @Post()
   create(@Body() createEventDto: CreateEventDto) {
     return this.eventService.create(createEventDto);
   }
 
+  @UseGuards(AuthGuard)
   @Get()
   findAll() {
     return this.eventService.findAll();
   }
 
+  @UseGuards(AuthGuard)
   @Get(':id')
   findOne(@Param('id') id: string) {
     this.validateEventId(id);
     return this.eventService.findOne(+id);
   }
 
+  @UseGuards(AuthGuard)
   @Get('user/:userId')
   findAllByUserId(
     @Param('userId') userId: string,
@@ -42,17 +48,20 @@ export class EventController {
     return this.eventService.findAllByUserId(+userId, limit);
   }
 
+  @UseGuards(AuthGuard)
   @Get('user/:userId/count')
   findNumberOfEventsByUserId(@Param('userId') userId: string) {
     return this.eventService.findNumberOfEventsByUserId(+userId);
   }
 
+  @UseGuards(AuthGuard)
   @Patch(':id')
   update(@Param('id') id: string, @Body() updateEventDto: UpdateEventDto) {
     this.validateEventId(id);
     return this.eventService.update(+id, updateEventDto);
   }
 
+  @UseGuards(AuthGuard)
   @Delete(':id')
   remove(@Param('id') id: string) {
     this.validateEventId(id);

--- a/src/event/event.controller.ts
+++ b/src/event/event.controller.ts
@@ -34,8 +34,7 @@ export class EventController {
 
   @UseGuards(AuthGuard)
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    this.validateEventId(id);
+  findOne(@Param('id', ParseIntPipe) id: number) {
     return this.eventService.findOne(+id);
   }
 

--- a/src/invoices/invoices.controller.ts
+++ b/src/invoices/invoices.controller.ts
@@ -7,6 +7,8 @@ import {
   Param,
   BadRequestException,
   UseGuards,
+  Delete,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { InvoicesService } from './invoices.service';
 import { CreateInvoiceDto } from './dto/create-invoice.dto';
@@ -43,10 +45,19 @@ export class InvoicesController {
     return this.invoicesService.update(+id, updateInvoiceDto);
   }
 
-  // @Delete(':id')
-  // remove(@Param('id') id: string) {
-  //   return this.invoicesService.remove(+id);
-  // }
+  @UseGuards(AuthGuard)
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    this.validateInvoiceId(id);
+    return this.invoicesService.remove(+id);
+  }
+
+  @UseGuards(AuthGuard)
+  @Delete('/event/:eventId')
+  removeByEventId(@Param('eventId', ParseIntPipe) eventId: number) {
+    return this.invoicesService.removeByEventId(eventId);
+  }
+
   validateInvoiceId(id: string) {
     if (isNaN(+id)) {
       throw new BadRequestException('Invoice id is not a number');

--- a/src/invoices/invoices.controller.ts
+++ b/src/invoices/invoices.controller.ts
@@ -1,28 +1,42 @@
-import { Controller, Get, Post, Body, Patch, Param, BadRequestException } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  BadRequestException,
+  UseGuards,
+} from '@nestjs/common';
 import { InvoicesService } from './invoices.service';
 import { CreateInvoiceDto } from './dto/create-invoice.dto';
 import { UpdateInvoiceDto } from './dto/update-invoice.dto';
+import { AuthGuard } from 'src/auth/auth.guard';
 
 @Controller('invoices')
 export class InvoicesController {
   constructor(private readonly invoicesService: InvoicesService) {}
 
+  @UseGuards(AuthGuard)
   @Post()
   create(@Body() createInvoiceDto: CreateInvoiceDto) {
     return this.invoicesService.create(createInvoiceDto);
   }
 
+  @UseGuards(AuthGuard)
   @Get()
   findAll() {
     return this.invoicesService.findAll();
   }
 
+  @UseGuards(AuthGuard)
   @Get(':id')
   findOne(@Param('id') id: string) {
     this.validateInvoiceId(id);
     return this.invoicesService.findOne(+id);
   }
 
+  @UseGuards(AuthGuard)
   @Patch(':id')
   update(@Param('id') id: string, @Body() updateInvoiceDto: UpdateInvoiceDto) {
     this.validateInvoiceId(id);

--- a/src/invoices/invoices.service.ts
+++ b/src/invoices/invoices.service.ts
@@ -38,7 +38,18 @@ export class InvoicesService {
     return this.invoiceRepository.save(updatedInvoice);
   }
 
-  // remove(id: number) {
-  //   return `This action removes a #${id} invoice`;
-  // }
+  async remove(id: number) {
+    const foundInvoice = await this.invoiceRepository.findOneBy({ id });
+    if (!foundInvoice) {
+      throw new NotFoundException('Invoice not found');
+    }
+    return this.invoiceRepository.remove(foundInvoice);
+  }
+
+  async removeByEventId(eventId: number) {
+    const foundInvoice = await this.invoiceRepository.find({
+      where: { event: { id: eventId } },
+    });
+    return this.invoiceRepository.remove(foundInvoice);
+  }
 }

--- a/src/levels/levels.controller.ts
+++ b/src/levels/levels.controller.ts
@@ -1,22 +1,35 @@
-import { Controller, Get, Post, Body, Param, Delete, BadRequestException } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Delete,
+  BadRequestException,
+  UseGuards,
+} from '@nestjs/common';
 import { LevelsService } from './levels.service';
 import { CreateLevelDto } from './dto/create-level.dto';
+import { AuthGuard } from 'src/auth/auth.guard';
 // import { UpdateLevelDto } from './dto/update-level.dto';
 
 @Controller('levels')
 export class LevelsController {
   constructor(private readonly levelsService: LevelsService) {}
 
+  @UseGuards(AuthGuard)
   @Post()
   create(@Body() createLevelDto: CreateLevelDto) {
     return this.levelsService.create(createLevelDto);
   }
 
+  @UseGuards(AuthGuard)
   @Get()
   findAll() {
     return this.levelsService.findAll();
   }
 
+  @UseGuards(AuthGuard)
   @Get(':id')
   findOne(@Param('id') id: string) {
     this.validateLevelId(id);
@@ -28,6 +41,7 @@ export class LevelsController {
   //   return this.levelsService.update(+id, updateLevelDto);
   // }
 
+  @UseGuards(AuthGuard)
   @Delete(':id')
   remove(@Param('id') id: string) {
     return this.levelsService.remove(+id);

--- a/src/locations/locations.controller.ts
+++ b/src/locations/locations.controller.ts
@@ -1,17 +1,20 @@
-import { Controller, Get, Post, Body, Param, Delete, Query } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, Delete, Query, UseGuards } from '@nestjs/common';
 import { LocationsService } from './locations.service';
 import { CreateLocationDto } from './dto/create-location.dto';
+import { AuthGuard } from 'src/auth/auth.guard';
 // import { UpdateLocationDto } from './dto/update-location.dto';
 
 @Controller('locations')
 export class LocationsController {
   constructor(private readonly locationsService: LocationsService) {}
 
+  @UseGuards(AuthGuard)
   @Post()
   create(@Body() createLocationDto: CreateLocationDto) {
     return this.locationsService.create(createLocationDto);
   }
 
+  @UseGuards(AuthGuard)
   @Get()
   findAll(@Query('latitude') lat: string, @Query('longitude') long: string) {
     if (lat && long) {
@@ -20,6 +23,7 @@ export class LocationsController {
     return this.locationsService.findAll();
   }
 
+  @UseGuards(AuthGuard)
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.locationsService.findOne(+id);
@@ -29,6 +33,7 @@ export class LocationsController {
   // update(@Param('id') id: string, @Body() updateLocationDto: UpdateLocationDto) {
   //   return this.locationService.update(+id, updateLocationDto);
   // }
+  @UseGuards(AuthGuard)
   @Delete(':id')
   remove(@Param('id') id: string) {
     return this.locationsService.remove(+id);

--- a/src/service/service.controller.ts
+++ b/src/service/service.controller.ts
@@ -6,37 +6,43 @@ import {
   Patch,
   Param,
   Delete,
-  BadRequestException,
   ParseIntPipe,
+  UseGuards,
 } from '@nestjs/common';
 import { ServiceService } from './service.service';
 import { CreateServiceDto } from './dto/create-service.dto';
 import { UpdateServiceDto } from './dto/update-service.dto';
+import { AuthGuard } from 'src/auth/auth.guard';
 
 @Controller('services')
 export class ServiceController {
   constructor(private readonly serviceService: ServiceService) {}
 
+  @UseGuards(AuthGuard)
   @Post()
   create(@Body() createServiceDto: CreateServiceDto) {
     return this.serviceService.create(createServiceDto);
   }
 
+  @UseGuards(AuthGuard)
   @Get()
   findAll() {
     return this.serviceService.findAll();
   }
 
+  @UseGuards(AuthGuard)
   @Get(':id')
   findOne(@Param('id', ParseIntPipe) id: number) {
     return this.serviceService.findOne(id);
   }
 
+  @UseGuards(AuthGuard)
   @Patch(':id')
   update(@Param('id', ParseIntPipe) id: number, @Body() updateServiceDto: UpdateServiceDto) {
     return this.serviceService.update(id, updateServiceDto);
   }
 
+  @UseGuards(AuthGuard)
   @Delete(':id')
   remove(@Param('id', ParseIntPipe) id: number) {
     return this.serviceService.remove(id);

--- a/src/steps/steps.controller.ts
+++ b/src/steps/steps.controller.ts
@@ -1,17 +1,20 @@
-import { Controller, Get, Post, Body, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, Delete, UseGuards } from '@nestjs/common';
 import { StepsService } from './steps.service';
 import { CreateStepDto } from './dto/create-step.dto';
+import { AuthGuard } from 'src/auth/auth.guard';
 // import { UpdateStepDto } from './dto/update-step.dto';
 
 @Controller('steps')
 export class StepsController {
   constructor(private readonly stepsService: StepsService) {}
 
+  @UseGuards(AuthGuard)
   @Post()
   create(@Body() createStepDto: CreateStepDto) {
     return this.stepsService.create(createStepDto);
   }
 
+  @UseGuards(AuthGuard)
   @Get()
   findAll() {
     return this.stepsService.findAll();
@@ -27,6 +30,7 @@ export class StepsController {
   //   return this.stepsService.update(+id, updateStepDto);
   // }
 
+  @UseGuards(AuthGuard)
   @Delete(':id')
   remove(@Param('id') id: string) {
     return this.stepsService.remove(+id);

--- a/src/subscription/subscription.controller.ts
+++ b/src/subscription/subscription.controller.ts
@@ -7,41 +7,49 @@ import {
   Param,
   BadRequestException,
   ParseIntPipe,
+  UseGuards,
 } from '@nestjs/common';
 import { SubscriptionService } from './subscription.service';
 import { CreateSubscriptionDto } from './dto/create-subscription.dto';
 import { UpdateSubscriptionDto } from './dto/update-subscription.dto';
+import { AuthGuard } from 'src/auth/auth.guard';
 
 @Controller('subscriptions')
 export class SubscriptionController {
   constructor(private readonly subscriptionService: SubscriptionService) {}
 
+  @UseGuards(AuthGuard)
   @Post()
   create(@Body() createSubscriptionDto: CreateSubscriptionDto) {
     return this.subscriptionService.create(createSubscriptionDto);
   }
 
+  @UseGuards(AuthGuard)
   @Get()
   findAll() {
     return this.subscriptionService.findAll();
   }
 
+  @UseGuards(AuthGuard)
   @Get(':id')
   findOne(@Param('id') id: string) {
     this.validateId(id);
     return this.subscriptionService.findOne(+id);
   }
 
+  @UseGuards(AuthGuard)
   @Get('/user/:userId')
   findSubscriptionsByUserId(@Param('userId', ParseIntPipe) userId: number) {
     return this.subscriptionService.findAllByUserId(userId);
   }
 
+  @UseGuards(AuthGuard)
   @Get('/car/:carId')
   findSubscriptionByCarId(@Param('carId', ParseIntPipe) carId: number) {
     return this.subscriptionService.findSubscriptionByCarId(carId);
   }
 
+  @UseGuards(AuthGuard)
   @Patch(':id')
   update(@Param('id') id: string, @Body() updateSubscriptionDto: UpdateSubscriptionDto) {
     this.validateId(id);

--- a/src/terminal/terminal.controller.ts
+++ b/src/terminal/terminal.controller.ts
@@ -8,20 +8,24 @@ import {
   Delete,
   ParseIntPipe,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 import { TerminalService } from './terminal.service';
 import { CreateTerminalDto } from './dto/create-terminal.dto';
 import { UpdateTerminalDto } from './dto/update-terminal.dto';
+import { AuthGuard } from 'src/auth/auth.guard';
 
 @Controller('terminals')
 export class TerminalController {
   constructor(private readonly terminalService: TerminalService) {}
 
+  @UseGuards(AuthGuard)
   @Post()
   create(@Body() createTerminalDto: CreateTerminalDto) {
     return this.terminalService.create(createTerminalDto);
   }
 
+  @UseGuards(AuthGuard)
   @Get('available')
   findTerminalByServiceId(
     @Query('serviceId', ParseIntPipe) serviceId: number,
@@ -32,26 +36,31 @@ export class TerminalController {
     }
   }
 
+  @UseGuards(AuthGuard)
   @Get()
   findAll() {
     return this.terminalService.findAll();
   }
 
+  @UseGuards(AuthGuard)
   @Get(':id')
   findOne(@Param('id', ParseIntPipe) id: number) {
     return this.terminalService.findOne(id);
   }
 
+  @UseGuards(AuthGuard)
   @Get('location/:locationId')
   findAllByLocationId(@Param('locationId', ParseIntPipe) locationId: number) {
     return this.terminalService.findAllByLocationId(locationId);
   }
 
+  @UseGuards(AuthGuard)
   @Patch(':id')
   update(@Param('id', ParseIntPipe) id: number, @Body() updateTerminalDto: UpdateTerminalDto) {
     return this.terminalService.update(id, updateTerminalDto);
   }
 
+  @UseGuards(AuthGuard)
   @Delete(':id')
   remove(@Param('id', ParseIntPipe) id: number) {
     return this.terminalService.remove(id);

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -7,32 +7,38 @@ import {
   Param,
   Delete,
   BadRequestException,
+  UseGuards,
 } from '@nestjs/common';
 import { UserService } from './user.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { AuthGuard } from 'src/auth/auth.guard';
 // import { AdminGuard } from './user.guards';
 
 @Controller('user')
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
+  @UseGuards(AuthGuard)
   @Post()
   create(@Body() createUserDto: CreateUserDto) {
     return this.userService.create(createUserDto);
   }
 
+  @UseGuards(AuthGuard)
   @Get()
   findAll() {
     return this.userService.findAll();
   }
 
+  @UseGuards(AuthGuard)
   @Get(':id')
   findOne(@Param('id') id: string) {
     this.validateUserId(id);
     return this.userService.findOne(+id);
   }
 
+  @UseGuards(AuthGuard)
   @Patch(':id')
   update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
     this.validateUserId(id);
@@ -40,6 +46,7 @@ export class UserController {
   }
 
   // @UseGuards(AdminGuard)
+  @UseGuards(AuthGuard)
   @Delete(':id')
   remove(@Param('id') id: string) {
     this.validateUserId(id);

--- a/test/cars.controller.e2e-spec.ts
+++ b/test/cars.controller.e2e-spec.ts
@@ -28,11 +28,11 @@ describe('Car Controller (e2e)', () => {
     carService = moduleFixture.get<CarService>(CarService);
 
     // Sign up
-    const userDTO = new CreateUserDto('test', 'user', 'testuser@mail.com', '12345');
+    const userDTO = new CreateUserDto('test', 'user', 'testuser1@mail.com', '12345');
     user = await userService.create(userDTO);
 
     // Log in
-    const loginDTO = new LoginDto('test4@mail.com', '12345');
+    const loginDTO = new LoginDto('testuser1@mail.com', '12345');
     const loginResponse = await authService.login(loginDTO);
     token = loginResponse.token;
 

--- a/test/cars.controller.e2e-spec.ts
+++ b/test/cars.controller.e2e-spec.ts
@@ -2,19 +2,43 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from 'src/app.module';
+import { UserService } from 'src/user/user.service';
+import { AuthService } from 'src/auth/auth.service';
+import { User } from 'src/user/entities/user.entity';
+import { CreateUserDto } from 'src/user/dto/create-user.dto';
+import { LoginDto } from 'src/auth/dto/login.dto';
 import { CarService } from 'src/car/car.service';
 import { CreateCarDto } from 'src/car/dto/create-car.dto';
 
 describe('Car Controller (e2e)', () => {
   let app: INestApplication;
   let carService: CarService;
+  let userService: UserService;
+  let authService: AuthService;
+  let token: string;
+  let user: User;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
 
+    userService = moduleFixture.get<UserService>(UserService);
+    authService = moduleFixture.get<AuthService>(AuthService);
     carService = moduleFixture.get<CarService>(CarService);
+
+    // Sign up
+    const userDTO = new CreateUserDto('test', 'user', 'testuser@mail.com', '12345');
+    user = await userService.create(userDTO);
+
+    // Log in
+    const loginDTO = new LoginDto('test4@mail.com', '12345');
+    const loginResponse = await authService.login(loginDTO);
+    token = loginResponse.token;
+
+    // Add a car
+    // car = await carService.create({ plateNumber: 'AZ98765', name: 'Testcar', userId: 1 });
+
     app = moduleFixture.createNestApplication();
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
@@ -22,34 +46,39 @@ describe('Car Controller (e2e)', () => {
 
   describe('/cars (GET)', () => {
     it('should return 200 and an array of cars', async () => {
-      const response = await request(app.getHttpServer()).get('/cars');
+      const response = await request(app.getHttpServer()).get('/cars').set('Authorization', token);
       expect(response.statusCode).toBe(200);
       expect(response.body).toBeDefined();
       expect(Array.isArray(response.body)).toBe(true);
     });
   });
-  // FIXME:
-  //   describe('/cars/id (GET)', () => {
-  //     it('should return a car based on its id', async () => {
-  //       const newCar = new CreateCarDto();
-  //       newCar.plateNumber = 'AB123CD';
-  //       newCar.userId = 1;
-  //       newCar.subscriptionId = 1;
+  describe('/cars/id (GET)', () => {
+    it('should return a car based on its id', async () => {
+      const newCar = new CreateCarDto();
+      newCar.plateNumber = 'AB123CD';
+      newCar.name = 'Testcar';
+      newCar.userId = 1;
 
-  //       const carCreated = await carService.create(newCar);
+      const carCreated = await carService.create(newCar);
 
-  //       const response = await request(app.getHttpServer()).get(`/cars/${carCreated.id}`);
+      const response = await request(app.getHttpServer())
+        .get(`/cars/${carCreated.id}`)
+        .set('Authorization', token);
 
-  //       expect(response.statusCode).toBe(200);
-  //       expect(response.body).toBeDefined();
-  //       expect(response.body.plateNumber).toBe('AB123CD');
-  //     });
-  //   });
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toBeDefined();
+      expect(response.body.plateNumber).toBe('AB123CD');
+
+      await carService.remove(response.body.id);
+    });
+  });
 
   describe('/cars/user/id (GET)', () => {
     it('should return cars based on user id', async () => {
       const userId = 1;
-      const response = await request(app.getHttpServer()).get(`/cars/user/${userId}`);
+      const response = await request(app.getHttpServer())
+        .get(`/cars/user/${userId}`)
+        .set('Authorization', token);
 
       expect(response.statusCode).toBe(200);
       expect(response.body).toBeDefined();
@@ -60,29 +89,36 @@ describe('Car Controller (e2e)', () => {
   describe('/cars (POST)', () => {
     it('should return 400 status code if invalid data', async () => {
       const invalidCar = { plateNumber: 12345 };
-      const response = await request(app.getHttpServer()).post('/cars').send(invalidCar);
+      const response = await request(app.getHttpServer())
+        .post('/cars')
+        .set('Authorization', token)
+        .send(invalidCar);
       expect(response.statusCode).toBe(400);
     });
-    // FIXME:
-    // it('should return 201 and the new car after creation', async () => {
-    //   const newCar = {
-    //     plateNumber: 'EF456GH',
-    //     userId: 2,
-    //     subscriptionId: 3,
-    //   };
 
-    //   const response = await request(app.getHttpServer()).post('/cars').send(newCar);
+    it('should return 201 and the new car after creation', async () => {
+      const newCar = {
+        plateNumber: 'EF456GH',
+        name: 'Testcar',
+        userId: 1,
+      };
 
-    //   expect(response.statusCode).toBe(201);
-    //   expect(response.body).toBeDefined();
-    //   expect(response.body.id).toBeDefined();
+      const response = await request(app.getHttpServer())
+        .post('/cars')
+        .set('Authorization', token)
+        .send(newCar);
 
-    //   // delete the car at the end of the test
-    //   await carService.remove(response.body.id);
-    // });
+      expect(response.statusCode).toBe(201);
+      expect(response.body).toBeDefined();
+      expect(response.body.id).toBeDefined();
+
+      // delete the car at the end of the test
+      await carService.remove(response.body.id);
+    });
   });
 
   afterAll(async () => {
+    await userService.remove(user.id);
     await app.close();
   });
 });

--- a/test/events.controller.e2e-spec.ts
+++ b/test/events.controller.e2e-spec.ts
@@ -4,10 +4,21 @@ import * as request from 'supertest';
 import { AppModule } from 'src/app.module';
 import { EventService } from 'src/event/event.service';
 import { CreateEventDto } from 'src/event/dto/create-event.dto';
+import { UserService } from 'src/user/user.service';
+import { AuthService } from 'src/auth/auth.service';
+import { User } from 'src/user/entities/user.entity';
+import { CreateUserDto } from 'src/user/dto/create-user.dto';
+import { LoginDto } from 'src/auth/dto/login.dto';
+import { InvoicesService } from 'src/invoices/invoices.service';
 
 describe('Events Controller (e2e)', () => {
   let app: INestApplication;
   let eventsService: EventService;
+  let invoicesService: InvoicesService;
+  let userService: UserService;
+  let authService: AuthService;
+  let token: string;
+  let user: User;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -15,6 +26,19 @@ describe('Events Controller (e2e)', () => {
     }).compile();
 
     eventsService = moduleFixture.get<EventService>(EventService);
+    invoicesService = moduleFixture.get<InvoicesService>(InvoicesService);
+    userService = moduleFixture.get<UserService>(UserService);
+    authService = moduleFixture.get<AuthService>(AuthService);
+
+    // Sign up
+    const userDTO = new CreateUserDto('test', 'user', 'testuser@mail.com', '12345');
+    user = await userService.create(userDTO);
+
+    // Log in
+    const loginDTO = new LoginDto('test4@mail.com', '12345');
+    const loginResponse = await authService.login(loginDTO);
+    token = loginResponse.token;
+
     app = moduleFixture.createNestApplication();
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
@@ -22,84 +46,92 @@ describe('Events Controller (e2e)', () => {
 
   describe('/events (GET)', () => {
     it('should return 200 and an array of levels', async () => {
-      const response = await request(app.getHttpServer()).get('/events');
+      const response = await request(app.getHttpServer())
+        .get('/events')
+        .set('Authorization', token);
       expect(response.statusCode).toBe(200);
       expect(response.body).toBeDefined();
       expect(Array.isArray(response.body)).toBe(true);
     });
   });
-
   describe('/events (POST)', () => {
-    it('should return 400 status code if invalid data', async () => {
-      const eventDTO = new CreateEventDto({ carId: 99999999 });
-      const response = await request(app.getHttpServer()).post('/events').send(eventDTO);
-      expect(response.statusCode).toBe(400);
+    it('should return 404 status code if IDs are not found', async () => {
+      const eventDTO = new CreateEventDto(9999, 9999, 9999);
+      const response = await request(app.getHttpServer())
+        .post('/events')
+        .set('Authorization', token)
+        .send(eventDTO);
+      expect(response.statusCode).toBe(404);
     });
 
-    // FIXME: This test is failing because the terminal id does not exist yet
-    // it('should return 201 and the new event after creation', async () => {
-    //   const eventDTO = new CreateEventDto({ carId: 1, serviceId: 1, terminalId: 1 });
-    //   const response = await request(app.getHttpServer()).post('/events').send(eventDTO);
+    it('should return 201 and the new event after creation', async () => {
+      const eventDTO = new CreateEventDto(3, 1, 1);
+      const response = await request(app.getHttpServer())
+        .post('/events')
+        .set('Authorization', token)
+        .send(eventDTO);
+      expect(response.statusCode).toBe(201);
+      expect(response.body).toBeDefined();
+      expect(response.body.id).toBeDefined();
 
-    //   expect(response.statusCode).toBe(201);
-    //   expect(response.body).toBeDefined();
-    //   expect(response.body.id).toBeDefined();
-
-    //   // delete the level at the end of the test
-    //   eventsService.remove(response.body.id);
-    // });
+      // delete the invoice and event at the end of the test
+      await invoicesService.removeByEventId(response.body.id);
+      await eventsService.remove(response.body.id);
+    });
   });
 
   describe('/events/:id (PATCH)', () => {
     it('should return 400 status code if event id is not a number', async () => {
-      const response = await request(app.getHttpServer()).patch('/events/aasasdfasdf');
+      const response = await request(app.getHttpServer())
+        .patch('/events/aasasdfasdf')
+        .set('Authorization', token);
       expect(response.statusCode).toBe(400);
       expect(response.body.message).toBe('Event id is not a number');
     });
 
-    // FIXME: This test is failing because the terminal id does not exist yet
-    // it('should return 404 if user not found', async () => {
-    //   const response = await request(app.getHttpServer())
-    //     .patch('/user/999999')
-    //     .set('Authorization', token);
-    //   expect(response.statusCode).toBe(404);
-    //   expect(response.body.message).toBe('User not found');
-    // });
+    it('should return 404 if user not found', async () => {
+      const response = await request(app.getHttpServer())
+        .patch('/user/999999')
+        .set('Authorization', token);
+      expect(response.statusCode).toBe(404);
+      expect(response.body.message).toBe('User not found');
+    });
 
-    // it('should return 400 status code if invalid data', async () => {
-    //   const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail@john.com', 'qwerty');
-    //   const newUser = await userService.create(newUserDTO);
-    //   const invalidUser = { ...newUser, firstName: 1234 };
+    it('should return 400 status code if invalid data', async () => {
+      const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail@john.com', 'qwerty');
+      const newUser = await userService.create(newUserDTO);
+      const invalidUser = { ...newUser, firstName: 1234 };
 
-    //   const response = await request(app.getHttpServer())
-    //     .patch(`/user/${invalidUser.id}`)
-    //     .set('Authorization', token)
-    //     .send(invalidUser);
+      const response = await request(app.getHttpServer())
+        .patch(`/user/${invalidUser.id}`)
+        .set('Authorization', token)
+        .send(invalidUser);
 
-    //   expect(response.statusCode).toBe(400);
+      expect(response.statusCode).toBe(400);
 
-    //   await userService.remove(newUser.id);
-    // });
+      await userService.remove(newUser.id);
+    });
 
-    // it('should return 200 and the updated data', async () => {
-    //   const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail@john.com', 'qwerty');
-    //   const newUser = await userService.create(newUserDTO);
-    //   const updatedUser = { ...newUser, firstName: 'updated firstName' };
+    it('should return 200 and the updated data', async () => {
+      const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail@john.com', 'qwerty');
+      const newUser = await userService.create(newUserDTO);
+      const updatedUser = { ...newUser, firstName: 'updated firstName' };
 
-    //   const response = await request(app.getHttpServer())
-    //     .patch(`/user/${updatedUser.id}`)
-    //     .set('Authorization', token)
-    //     .send(updatedUser);
+      const response = await request(app.getHttpServer())
+        .patch(`/user/${updatedUser.id}`)
+        .set('Authorization', token)
+        .send(updatedUser);
 
-    //   expect(response.statusCode).toBe(200);
-    //   expect(response.body).toBeDefined();
-    //   expect(response.body.firstName).toBe('Updated Firstname');
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toBeDefined();
+      expect(response.body.firstName).toBe('Updated Firstname');
 
-    //   await userService.remove(newUser.id);
-    // });
+      await userService.remove(newUser.id);
+    });
   });
 
   afterAll(async () => {
+    await userService.remove(user.id);
     await app.close();
   });
 });

--- a/test/events.controller.e2e-spec.ts
+++ b/test/events.controller.e2e-spec.ts
@@ -10,15 +10,19 @@ import { User } from 'src/user/entities/user.entity';
 import { CreateUserDto } from 'src/user/dto/create-user.dto';
 import { LoginDto } from 'src/auth/dto/login.dto';
 import { InvoicesService } from 'src/invoices/invoices.service';
+import { Car } from 'src/car/entities/car.entity';
+import { CarService } from 'src/car/car.service';
 
 describe('Events Controller (e2e)', () => {
   let app: INestApplication;
-  let eventsService: EventService;
   let invoicesService: InvoicesService;
+  let eventsService: EventService;
+  let carService: CarService;
   let userService: UserService;
   let authService: AuthService;
   let token: string;
   let user: User;
+  let car: Car;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -29,6 +33,7 @@ describe('Events Controller (e2e)', () => {
     invoicesService = moduleFixture.get<InvoicesService>(InvoicesService);
     userService = moduleFixture.get<UserService>(UserService);
     authService = moduleFixture.get<AuthService>(AuthService);
+    carService = moduleFixture.get<CarService>(CarService);
 
     // Sign up
     const userDTO = new CreateUserDto('test', 'user', 'testuser@mail.com', '12345');
@@ -38,6 +43,9 @@ describe('Events Controller (e2e)', () => {
     const loginDTO = new LoginDto('test4@mail.com', '12345');
     const loginResponse = await authService.login(loginDTO);
     token = loginResponse.token;
+
+    // Add a car
+    car = await carService.create({ plateNumber: 'AZ98765', name: 'Testcar', userId: 1 });
 
     app = moduleFixture.createNestApplication();
     app.useGlobalPipes(new ValidationPipe());
@@ -73,7 +81,7 @@ describe('Events Controller (e2e)', () => {
     });
 
     it('should return 201 and the new event after creation', async () => {
-      const eventDTO = new CreateEventDto(3, 1, 1);
+      const eventDTO = new CreateEventDto(1, 1, 1);
       const response = await request(app.getHttpServer())
         .post('/events')
         .set('Authorization', token)
@@ -139,6 +147,7 @@ describe('Events Controller (e2e)', () => {
   });
 
   afterAll(async () => {
+    await carService.remove(car.id);
     await userService.remove(user.id);
     await app.close();
   });

--- a/test/events.controller.e2e-spec.ts
+++ b/test/events.controller.e2e-spec.ts
@@ -53,7 +53,15 @@ describe('Events Controller (e2e)', () => {
       expect(response.body).toBeDefined();
       expect(Array.isArray(response.body)).toBe(true);
     });
+
+    it('should return 400 status code if ID is not a string', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/events/a99')
+        .set('Authorization', token);
+      expect(response.statusCode).toBe(400);
+    });
   });
+
   describe('/events (POST)', () => {
     it('should return 404 status code if IDs are not found', async () => {
       const eventDTO = new CreateEventDto(9999, 9999, 9999);

--- a/test/events.controller.e2e-spec.ts
+++ b/test/events.controller.e2e-spec.ts
@@ -36,11 +36,11 @@ describe('Events Controller (e2e)', () => {
     carService = moduleFixture.get<CarService>(CarService);
 
     // Sign up
-    const userDTO = new CreateUserDto('test', 'user', 'testuser@mail.com', '12345');
+    const userDTO = new CreateUserDto('test', 'user', 'testuser2@mail.com', '12345');
     user = await userService.create(userDTO);
 
     // Log in
-    const loginDTO = new LoginDto('test4@mail.com', '12345');
+    const loginDTO = new LoginDto('testuser2@mail.com', '12345');
     const loginResponse = await authService.login(loginDTO);
     token = loginResponse.token;
 
@@ -129,7 +129,7 @@ describe('Events Controller (e2e)', () => {
     });
 
     it('should return 200 and the updated data', async () => {
-      const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail@john.com', 'qwerty');
+      const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail5@john.com', 'qwerty');
       const newUser = await userService.create(newUserDTO);
       const updatedUser = { ...newUser, firstName: 'updated firstName' };
 

--- a/test/invoices.controller.e2e-spec.ts
+++ b/test/invoices.controller.e2e-spec.ts
@@ -37,11 +37,11 @@ describe('Events Controller (e2e)', () => {
     carService = moduleFixture.get<CarService>(CarService);
 
     // Sign up
-    const userDTO = new CreateUserDto('test', 'user', 'testuser@mail.com', '12345');
+    const userDTO = new CreateUserDto('test', 'user', 'testuser3@mail.com', '12345');
     user = await userService.create(userDTO);
 
     // Log in
-    const loginDTO = new LoginDto('test4@mail.com', '12345');
+    const loginDTO = new LoginDto('testuser3@mail.com', '12345');
     const loginResponse = await authService.login(loginDTO);
     token = loginResponse.token;
 
@@ -125,7 +125,7 @@ describe('Events Controller (e2e)', () => {
     });
 
     it('should return 200 and the updated data', async () => {
-      const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail@john.com', 'qwerty');
+      const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail6@john.com', 'qwerty');
       const newUser = await userService.create(newUserDTO);
       const updatedUser = { ...newUser, firstName: 'updated firstName' };
 

--- a/test/invoices.controller.e2e-spec.ts
+++ b/test/invoices.controller.e2e-spec.ts
@@ -2,12 +2,28 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from 'src/app.module';
+import { EventService } from 'src/event/event.service';
+import { UserService } from 'src/user/user.service';
+import { AuthService } from 'src/auth/auth.service';
+import { User } from 'src/user/entities/user.entity';
+import { CreateUserDto } from 'src/user/dto/create-user.dto';
+import { LoginDto } from 'src/auth/dto/login.dto';
 import { InvoicesService } from 'src/invoices/invoices.service';
 import { CreateInvoiceDto } from 'src/invoices/dto/create-invoice.dto';
+import { CreateEventDto } from 'src/event/dto/create-event.dto';
+import { CarService } from 'src/car/car.service';
+import { Car } from 'src/car/entities/car.entity';
 
 describe('Events Controller (e2e)', () => {
   let app: INestApplication;
   let invoicesService: InvoicesService;
+  let eventsService: EventService;
+  let carService: CarService;
+  let userService: UserService;
+  let authService: AuthService;
+  let token: string;
+  let user: User;
+  let car: Car;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -15,6 +31,23 @@ describe('Events Controller (e2e)', () => {
     }).compile();
 
     invoicesService = moduleFixture.get<InvoicesService>(InvoicesService);
+    eventsService = moduleFixture.get<EventService>(EventService);
+    userService = moduleFixture.get<UserService>(UserService);
+    authService = moduleFixture.get<AuthService>(AuthService);
+    carService = moduleFixture.get<CarService>(CarService);
+
+    // Sign up
+    const userDTO = new CreateUserDto('test', 'user', 'testuser@mail.com', '12345');
+    user = await userService.create(userDTO);
+
+    // Log in
+    const loginDTO = new LoginDto('test4@mail.com', '12345');
+    const loginResponse = await authService.login(loginDTO);
+    token = loginResponse.token;
+
+    // Add a car
+    car = await carService.create({ plateNumber: 'AZ98765', name: 'Testcar', userId: 1 });
+
     app = moduleFixture.createNestApplication();
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
@@ -22,7 +55,9 @@ describe('Events Controller (e2e)', () => {
 
   describe('/invoices (GET)', () => {
     it('should return 200 and an array of invoices', async () => {
-      const response = await request(app.getHttpServer()).get('/invoices');
+      const response = await request(app.getHttpServer())
+        .get('/invoices')
+        .set('Authorization', token);
       expect(response.statusCode).toBe(200);
       expect(response.body).toBeDefined();
       expect(Array.isArray(response.body)).toBe(true);
@@ -31,75 +66,85 @@ describe('Events Controller (e2e)', () => {
 
   describe('/invoices (POST)', () => {
     it('should return 400 status code if invalid data', async () => {
-      const invoiceDTO = new CreateInvoiceDto({ eventId: 99999999 });
-      const response = await request(app.getHttpServer()).post('/invoices').send(invoiceDTO);
+      const invoiceDTO = new CreateInvoiceDto({ eventId: 9999999 });
+      const response = await request(app.getHttpServer())
+        .post('/invoices')
+        .set('Authorization', token)
+        .send(invoiceDTO);
       expect(response.statusCode).toBe(400);
     });
 
-    // FIXME: This test is failing because the terminal id does not exist yet
-    // it('should return 201 and the new event after creation', async () => {
-    //   const eventDTO = new CreateEventDto({ carId: 1, serviceId: 1, terminalId: 1 });
-    //   const response = await request(app.getHttpServer()).post('/events').send(eventDTO);
+    it('should return 201 and the new event after creation', async () => {
+      const eventDTO = new CreateEventDto(1, 1, 1);
+      const response = await request(app.getHttpServer())
+        .post('/events')
+        .set('Authorization', token)
+        .send(eventDTO);
 
-    //   expect(response.statusCode).toBe(201);
-    //   expect(response.body).toBeDefined();
-    //   expect(response.body.id).toBeDefined();
+      expect(response.statusCode).toBe(201);
+      expect(response.body).toBeDefined();
+      expect(response.body.id).toBeDefined();
 
-    //   // delete the level at the end of the test
-    //   eventsService.remove(response.body.id);
-    // });
+      // delete the level at the end of the test
+      await invoicesService.removeByEventId(response.body.id);
+      await eventsService.remove(response.body.id);
+    });
   });
 
   describe('/invoices/:id (PATCH)', () => {
     it('should return 400 status code if invoice id is not a number', async () => {
-      const response = await request(app.getHttpServer()).patch('/invoices/aasasdfasdf');
+      const response = await request(app.getHttpServer())
+        .patch('/invoices/aasasdfasdf')
+        .set('Authorization', token);
       expect(response.statusCode).toBe(400);
       expect(response.body.message).toBe('Invoice id is not a number');
     });
 
     // FIXME: This test is failing because the terminal id does not exist yet
-    // it('should return 404 if user not found', async () => {
-    //   const response = await request(app.getHttpServer())
-    //     .patch('/user/999999')
-    //     .set('Authorization', token);
-    //   expect(response.statusCode).toBe(404);
-    //   expect(response.body.message).toBe('User not found');
-    // });
+    it('should return 404 if user not found', async () => {
+      const response = await request(app.getHttpServer())
+        .patch('/user/999999')
+        .set('Authorization', token);
+      expect(response.statusCode).toBe(404);
+      expect(response.body.message).toBe('User not found');
+    });
 
-    // it('should return 400 status code if invalid data', async () => {
-    //   const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail@john.com', 'qwerty');
-    //   const newUser = await userService.create(newUserDTO);
-    //   const invalidUser = { ...newUser, firstName: 1234 };
+    it('should return 400 status code if invalid data', async () => {
+      const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail@john.com', 'qwerty');
+      const newUser = await userService.create(newUserDTO);
+      const invalidUser = { ...newUser, firstName: 1234 };
 
-    //   const response = await request(app.getHttpServer())
-    //     .patch(`/user/${invalidUser.id}`)
-    //     .set('Authorization', token)
-    //     .send(invalidUser);
+      const response = await request(app.getHttpServer())
+        .patch(`/user/${invalidUser.id}`)
+        .set('Authorization', token)
+        .send(invalidUser);
 
-    //   expect(response.statusCode).toBe(400);
+      expect(response.statusCode).toBe(400);
 
-    //   await userService.remove(newUser.id);
-    // });
+      await userService.remove(newUser.id);
+    });
 
-    // it('should return 200 and the updated data', async () => {
-    //   const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail@john.com', 'qwerty');
-    //   const newUser = await userService.create(newUserDTO);
-    //   const updatedUser = { ...newUser, firstName: 'updated firstName' };
+    it('should return 200 and the updated data', async () => {
+      const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail@john.com', 'qwerty');
+      const newUser = await userService.create(newUserDTO);
+      const updatedUser = { ...newUser, firstName: 'updated firstName' };
 
-    //   const response = await request(app.getHttpServer())
-    //     .patch(`/user/${updatedUser.id}`)
-    //     .set('Authorization', token)
-    //     .send(updatedUser);
+      const response = await request(app.getHttpServer())
+        .patch(`/user/${updatedUser.id}`)
+        .set('Authorization', token)
+        .send(updatedUser);
 
-    //   expect(response.statusCode).toBe(200);
-    //   expect(response.body).toBeDefined();
-    //   expect(response.body.firstName).toBe('Updated Firstname');
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toBeDefined();
+      expect(response.body.firstName).toBe('Updated Firstname');
 
-    //   await userService.remove(newUser.id);
-    // });
+      await userService.remove(newUser.id);
+    });
   });
 
   afterAll(async () => {
+    await carService.remove(car.id);
+    await userService.remove(user.id);
     await app.close();
   });
 });

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -2,6 +2,7 @@
   "moduleFileExtensions": ["js", "json", "ts"],
   "rootDir": "..",
   "testEnvironment": "node",
+  "maxWorkers": 1,
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"

--- a/test/levels.controller.e2e-spec.ts
+++ b/test/levels.controller.e2e-spec.ts
@@ -19,37 +19,38 @@ describe('Level Controller (e2e)', () => {
     await app.init();
   });
 
-  describe('/levels (GET)', () => {
-    it('should return 200 and an array of levels', async () => {
-      const response = await request(app.getHttpServer()).get('/levels');
-      expect(response.statusCode).toBe(200);
-      expect(response.body).toBeDefined();
-      expect(Array.isArray(response.body)).toBe(true);
-    });
-  });
+  // FIXME SEND JWT TOKEN
+  // describe('/levels (GET)', () => {
+  //   it('should return 200 and an array of levels', async () => {
+  //     const response = await request(app.getHttpServer()).get('/levels');
+  //     expect(response.statusCode).toBe(200);
+  //     expect(response.body).toBeDefined();
+  //     expect(Array.isArray(response.body)).toBe(true);
+  //   });
+  // });
 
-  describe('/levels (POST)', () => {
-    it('should return 400 status code if invalid data', async () => {
-      const invalidLevel = { name: false };
-      const response = await request(app.getHttpServer()).post('/levels').send(invalidLevel);
-      expect(response.statusCode).toBe(400);
-    });
+  // describe('/levels (POST)', () => {
+  //   it('should return 400 status code if invalid data', async () => {
+  //     const invalidLevel = { name: false };
+  //     const response = await request(app.getHttpServer()).post('/levels').send(invalidLevel);
+  //     expect(response.statusCode).toBe(400);
+  //   });
 
-    it('should return 201 and the new level after creation', async () => {
-      const response = await request(app.getHttpServer())
-        .post('/levels')
-        .send({ name: 'TestLevel' });
+  //   it('should return 201 and the new level after creation', async () => {
+  //     const response = await request(app.getHttpServer())
+  //       .post('/levels')
+  //       .send({ name: 'TestLevel' });
 
-      expect(response.statusCode).toBe(201);
-      expect(response.body).toBeDefined();
-      expect(response.body.id).toBeDefined();
+  //     expect(response.statusCode).toBe(201);
+  //     expect(response.body).toBeDefined();
+  //     expect(response.body.id).toBeDefined();
 
-      // delete the level at the end of the test
-      await levelsService.remove(response.body.id);
-    });
-  });
+  //     // delete the level at the end of the test
+  //     await levelsService.remove(response.body.id);
+  //   });
+  // });
 
-  afterAll(async () => {
-    await app.close();
-  });
+  // afterAll(async () => {
+  //   await app.close();
+  // });
 });

--- a/test/levels.controller.e2e-spec.ts
+++ b/test/levels.controller.e2e-spec.ts
@@ -27,11 +27,11 @@ describe('Level Controller (e2e)', () => {
     levelsService = moduleFixture.get<LevelsService>(LevelsService);
 
     // Sign up
-    const userDTO = new CreateUserDto('test', 'user', 'testuser@mail.com', '12345');
+    const userDTO = new CreateUserDto('test', 'user', 'testuser4@mail.com', '12345');
     user = await userService.create(userDTO);
 
     // Log in
-    const loginDTO = new LoginDto('test4@mail.com', '12345');
+    const loginDTO = new LoginDto('testuser4@mail.com', '12345');
     const loginResponse = await authService.login(loginDTO);
     token = loginResponse.token;
 

--- a/test/levels.controller.e2e-spec.ts
+++ b/test/levels.controller.e2e-spec.ts
@@ -2,10 +2,19 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from 'src/app.module';
+import { UserService } from 'src/user/user.service';
+import { AuthService } from 'src/auth/auth.service';
+import { User } from 'src/user/entities/user.entity';
+import { CreateUserDto } from 'src/user/dto/create-user.dto';
+import { LoginDto } from 'src/auth/dto/login.dto';
 import { LevelsService } from 'src/levels/levels.service';
 
 describe('Level Controller (e2e)', () => {
   let app: INestApplication;
+  let userService: UserService;
+  let authService: AuthService;
+  let token: string;
+  let user: User;
   let levelsService: LevelsService;
 
   beforeAll(async () => {
@@ -13,44 +22,62 @@ describe('Level Controller (e2e)', () => {
       imports: [AppModule],
     }).compile();
 
+    userService = moduleFixture.get<UserService>(UserService);
+    authService = moduleFixture.get<AuthService>(AuthService);
     levelsService = moduleFixture.get<LevelsService>(LevelsService);
+
+    // Sign up
+    const userDTO = new CreateUserDto('test', 'user', 'testuser@mail.com', '12345');
+    user = await userService.create(userDTO);
+
+    // Log in
+    const loginDTO = new LoginDto('test4@mail.com', '12345');
+    const loginResponse = await authService.login(loginDTO);
+    token = loginResponse.token;
+
     app = moduleFixture.createNestApplication();
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
   });
 
   // FIXME SEND JWT TOKEN
-  // describe('/levels (GET)', () => {
-  //   it('should return 200 and an array of levels', async () => {
-  //     const response = await request(app.getHttpServer()).get('/levels');
-  //     expect(response.statusCode).toBe(200);
-  //     expect(response.body).toBeDefined();
-  //     expect(Array.isArray(response.body)).toBe(true);
-  //   });
-  // });
+  describe('/levels (GET)', () => {
+    it('should return 200 and an array of levels', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/levels')
+        .set('Authorization', token);
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toBeDefined();
+      expect(Array.isArray(response.body)).toBe(true);
+    });
+  });
 
-  // describe('/levels (POST)', () => {
-  //   it('should return 400 status code if invalid data', async () => {
-  //     const invalidLevel = { name: false };
-  //     const response = await request(app.getHttpServer()).post('/levels').send(invalidLevel);
-  //     expect(response.statusCode).toBe(400);
-  //   });
+  describe('/levels (POST)', () => {
+    it('should return 400 status code if invalid data', async () => {
+      const invalidLevel = { name: false };
+      const response = await request(app.getHttpServer())
+        .post('/levels')
+        .send(invalidLevel)
+        .set('Authorization', token);
+      expect(response.statusCode).toBe(400);
+    });
 
-  //   it('should return 201 and the new level after creation', async () => {
-  //     const response = await request(app.getHttpServer())
-  //       .post('/levels')
-  //       .send({ name: 'TestLevel' });
+    it('should return 201 and the new level after creation', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/levels')
+        .send({ name: 'TestLevel', price: 1234 })
+        .set('Authorization', token);
+      expect(response.statusCode).toBe(201);
+      expect(response.body).toBeDefined();
+      expect(response.body.id).toBeDefined();
 
-  //     expect(response.statusCode).toBe(201);
-  //     expect(response.body).toBeDefined();
-  //     expect(response.body.id).toBeDefined();
+      // delete the level at the end of the test
+      await levelsService.remove(response.body.id);
+    });
+  });
 
-  //     // delete the level at the end of the test
-  //     await levelsService.remove(response.body.id);
-  //   });
-  // });
-
-  // afterAll(async () => {
-  //   await app.close();
-  // });
+  afterAll(async () => {
+    await userService.remove(user.id);
+    await app.close();
+  });
 });

--- a/test/locations.controller.e2e-spec.ts
+++ b/test/locations.controller.e2e-spec.ts
@@ -29,11 +29,11 @@ describe('Location Controller (e2e)', () => {
     locationsService = moduleFixture.get<LocationsService>(LocationsService);
 
     // Sign up
-    const userDTO = new CreateUserDto('test', 'user', 'testuser@mail.com', '12345');
+    const userDTO = new CreateUserDto('test', 'user', 'testuser5@mail.com', '12345');
     user = await userService.create(userDTO);
 
     // Log in
-    const loginDTO = new LoginDto('test4@mail.com', '12345');
+    const loginDTO = new LoginDto('testuser5@mail.com', '12345');
     const loginResponse = await authService.login(loginDTO);
     token = loginResponse.token;
 

--- a/test/locations.controller.e2e-spec.ts
+++ b/test/locations.controller.e2e-spec.ts
@@ -21,92 +21,93 @@ describe('Location Controller (e2e)', () => {
     await app.init();
   });
 
-  describe('/locations (GET)', () => {
-    it('should return 200 and an array of locations', async () => {
-      const response = await request(app.getHttpServer()).get('/locations');
-      expect(response.statusCode).toBe(200);
-      expect(response.body).toBeDefined();
-      expect(Array.isArray(response.body)).toBe(true);
-    });
-  });
+  // FIXME SEND JWT TOKEN
+  // describe('/locations (GET)', () => {
+  //   it('should return 200 and an array of locations', async () => {
+  //     const response = await request(app.getHttpServer()).get('/locations');
+  //     expect(response.statusCode).toBe(200);
+  //     expect(response.body).toBeDefined();
+  //     expect(Array.isArray(response.body)).toBe(true);
+  //   });
+  // });
 
-  describe('/locations/id (GET)', () => {
-    it('should return a location based on its id', async () => {
-      const newlocation = new CreateLocationDto({
-        city: 'København',
-        streetName: 'Nørrebrogade',
-        streetNumber: '56',
-        postalCode: '2200',
-        openingHours: {
-          monday: { from: '00:00', to: '24:00' },
-          tuesday: { from: '00:00', to: '24:00' },
-          wednesday: { from: '00:00', to: '24:00' },
-          thursday: { from: '00:00', to: '24:00' },
-          friday: { from: '00:00', to: '24:00' },
-          saturday: { from: '00:00', to: '24:00' },
-          sunday: { from: 'Closed', to: 'Closed' },
-        },
-        status: LocationStatus.closed,
-        image: 'https://example.com/image3.jpg',
-        coordinates: {
-          latitude: 55.6887,
-          longitude: 12.5489,
-        },
-      });
+  // describe('/locations/id (GET)', () => {
+  //   it('should return a location based on its id', async () => {
+  //     const newlocation = new CreateLocationDto({
+  //       city: 'København',
+  //       streetName: 'Nørrebrogade',
+  //       streetNumber: '56',
+  //       postalCode: '2200',
+  //       openingHours: {
+  //         monday: { from: '00:00', to: '24:00' },
+  //         tuesday: { from: '00:00', to: '24:00' },
+  //         wednesday: { from: '00:00', to: '24:00' },
+  //         thursday: { from: '00:00', to: '24:00' },
+  //         friday: { from: '00:00', to: '24:00' },
+  //         saturday: { from: '00:00', to: '24:00' },
+  //         sunday: { from: 'Closed', to: 'Closed' },
+  //       },
+  //       status: LocationStatus.closed,
+  //       image: 'https://example.com/image3.jpg',
+  //       coordinates: {
+  //         latitude: 55.6887,
+  //         longitude: 12.5489,
+  //       },
+  //     });
 
-      const locationCreated = await locationsService.create(newlocation);
+  //     const locationCreated = await locationsService.create(newlocation);
 
-      const response = await request(app.getHttpServer()).get(`/locations/${locationCreated.id}`);
+  //     const response = await request(app.getHttpServer()).get(`/locations/${locationCreated.id}`);
 
-      expect(response.statusCode).toBe(200);
-      expect(response.body).toBeDefined();
-      expect(response.body.address).toBe('2200 København, Nørrebrogade 56');
-    });
-  });
+  //     expect(response.statusCode).toBe(200);
+  //     expect(response.body).toBeDefined();
+  //     expect(response.body.address).toBe('2200 København, Nørrebrogade 56');
+  //   });
+  // });
 
-  describe('/locations (POST)', () => {
-    it('should return 400 status code if invalid data', async () => {
-      const invalidLocation = { address: false };
-      const response = await request(app.getHttpServer()).post('/locations').send(invalidLocation);
-      expect(response.statusCode).toBe(400);
-    });
+  // describe('/locations (POST)', () => {
+  //   it('should return 400 status code if invalid data', async () => {
+  //     const invalidLocation = { address: false };
+  //     const response = await request(app.getHttpServer()).post('/locations').send(invalidLocation);
+  //     expect(response.statusCode).toBe(400);
+  //   });
 
-    it('should return 201 and the new location after creation', async () => {
-      const newLocation = {
-        address: 'Nørrebrogade 56, 2200 København',
-        city: 'København',
-        streetName: 'Nørrebrogade',
-        streetNumber: '56',
-        postalCode: '2200',
-        openingHours: {
-          monday: { from: '00:00', to: '24:00' },
-          tuesday: { from: '00:00', to: '24:00' },
-          wednesday: { from: '00:00', to: '24:00' },
-          thursday: { from: '00:00', to: '24:00' },
-          friday: { from: '00:00', to: '24:00' },
-          saturday: { from: '00:00', to: '24:00' },
-          sunday: { from: 'Closed', to: 'Closed' },
-        },
-        status: 'closed',
-        image: 'https://example.com/image3.jpg',
-        coordinates: {
-          latitude: 55.6887,
-          longitude: 12.5489,
-        },
-      };
+  //   it('should return 201 and the new location after creation', async () => {
+  //     const newLocation = {
+  //       address: 'Nørrebrogade 56, 2200 København',
+  //       city: 'København',
+  //       streetName: 'Nørrebrogade',
+  //       streetNumber: '56',
+  //       postalCode: '2200',
+  //       openingHours: {
+  //         monday: { from: '00:00', to: '24:00' },
+  //         tuesday: { from: '00:00', to: '24:00' },
+  //         wednesday: { from: '00:00', to: '24:00' },
+  //         thursday: { from: '00:00', to: '24:00' },
+  //         friday: { from: '00:00', to: '24:00' },
+  //         saturday: { from: '00:00', to: '24:00' },
+  //         sunday: { from: 'Closed', to: 'Closed' },
+  //       },
+  //       status: 'closed',
+  //       image: 'https://example.com/image3.jpg',
+  //       coordinates: {
+  //         latitude: 55.6887,
+  //         longitude: 12.5489,
+  //       },
+  //     };
 
-      const response = await request(app.getHttpServer()).post('/locations').send(newLocation);
+  //     const response = await request(app.getHttpServer()).post('/locations').send(newLocation);
 
-      expect(response.statusCode).toBe(201);
-      expect(response.body).toBeDefined();
-      expect(response.body.id).toBeDefined();
+  //     expect(response.statusCode).toBe(201);
+  //     expect(response.body).toBeDefined();
+  //     expect(response.body.id).toBeDefined();
 
-      // delete the location at the end of the test
-      await locationsService.remove(response.body.id);
-    });
-  });
+  //     // delete the location at the end of the test
+  //     await locationsService.remove(response.body.id);
+  //   });
+  // });
 
-  afterAll(async () => {
-    await app.close();
-  });
+  // afterAll(async () => {
+  //   await app.close();
+  // });
 });

--- a/test/locations.controller.e2e-spec.ts
+++ b/test/locations.controller.e2e-spec.ts
@@ -2,12 +2,21 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from 'src/app.module';
+import { UserService } from 'src/user/user.service';
+import { AuthService } from 'src/auth/auth.service';
+import { User } from 'src/user/entities/user.entity';
+import { CreateUserDto } from 'src/user/dto/create-user.dto';
+import { LoginDto } from 'src/auth/dto/login.dto';
+import { LocationStatus } from 'src/locations/entities/location.entity';
 import { LocationsService } from 'src/locations/locations.service';
 import { CreateLocationDto } from 'src/locations/dto/create-location.dto';
-import { LocationStatus } from 'src/locations/entities/location.entity';
 
 describe('Location Controller (e2e)', () => {
   let app: INestApplication;
+  let userService: UserService;
+  let authService: AuthService;
+  let token: string;
+  let user: User;
   let locationsService: LocationsService;
 
   beforeAll(async () => {
@@ -15,99 +24,124 @@ describe('Location Controller (e2e)', () => {
       imports: [AppModule],
     }).compile();
 
+    userService = moduleFixture.get<UserService>(UserService);
+    authService = moduleFixture.get<AuthService>(AuthService);
     locationsService = moduleFixture.get<LocationsService>(LocationsService);
+
+    // Sign up
+    const userDTO = new CreateUserDto('test', 'user', 'testuser@mail.com', '12345');
+    user = await userService.create(userDTO);
+
+    // Log in
+    const loginDTO = new LoginDto('test4@mail.com', '12345');
+    const loginResponse = await authService.login(loginDTO);
+    token = loginResponse.token;
+
     app = moduleFixture.createNestApplication();
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
   });
 
   // FIXME SEND JWT TOKEN
-  // describe('/locations (GET)', () => {
-  //   it('should return 200 and an array of locations', async () => {
-  //     const response = await request(app.getHttpServer()).get('/locations');
-  //     expect(response.statusCode).toBe(200);
-  //     expect(response.body).toBeDefined();
-  //     expect(Array.isArray(response.body)).toBe(true);
-  //   });
-  // });
+  describe('/locations (GET)', () => {
+    it('should return 200 and an array of locations', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/locations')
+        .set('Authorization', token);
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toBeDefined();
+      expect(Array.isArray(response.body)).toBe(true);
+    });
+  });
 
-  // describe('/locations/id (GET)', () => {
-  //   it('should return a location based on its id', async () => {
-  //     const newlocation = new CreateLocationDto({
-  //       city: 'København',
-  //       streetName: 'Nørrebrogade',
-  //       streetNumber: '56',
-  //       postalCode: '2200',
-  //       openingHours: {
-  //         monday: { from: '00:00', to: '24:00' },
-  //         tuesday: { from: '00:00', to: '24:00' },
-  //         wednesday: { from: '00:00', to: '24:00' },
-  //         thursday: { from: '00:00', to: '24:00' },
-  //         friday: { from: '00:00', to: '24:00' },
-  //         saturday: { from: '00:00', to: '24:00' },
-  //         sunday: { from: 'Closed', to: 'Closed' },
-  //       },
-  //       status: LocationStatus.closed,
-  //       image: 'https://example.com/image3.jpg',
-  //       coordinates: {
-  //         latitude: 55.6887,
-  //         longitude: 12.5489,
-  //       },
-  //     });
+  describe('/locations/id (GET)', () => {
+    it('should return a location based on its id', async () => {
+      const newLocation = new CreateLocationDto(
+        'København',
+        'Nørrebrogade',
+        '56',
+        '2200',
+        {
+          monday: { from: '00:00', to: '24:00' },
+          tuesday: { from: '00:00', to: '24:00' },
+          wednesday: { from: '00:00', to: '24:00' },
+          thursday: { from: '00:00', to: '24:00' },
+          friday: { from: '00:00', to: '24:00' },
+          saturday: { from: '00:00', to: '24:00' },
+          sunday: { from: 'Closed', to: 'Closed' },
+        },
+        LocationStatus.closed,
+        'https://example.com/image3.jpg',
+        {
+          latitude: 55.6887,
+          longitude: 12.5489,
+        },
+      );
 
-  //     const locationCreated = await locationsService.create(newlocation);
+      const locationCreated = await locationsService.create(newLocation);
 
-  //     const response = await request(app.getHttpServer()).get(`/locations/${locationCreated.id}`);
+      const response = await request(app.getHttpServer())
+        .get(`/locations/${locationCreated.id}`)
+        .set('Authorization', token);
 
-  //     expect(response.statusCode).toBe(200);
-  //     expect(response.body).toBeDefined();
-  //     expect(response.body.address).toBe('2200 København, Nørrebrogade 56');
-  //   });
-  // });
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toBeDefined();
+      expect(response.body.address).toBe('2200 København, Nørrebrogade 56');
 
-  // describe('/locations (POST)', () => {
-  //   it('should return 400 status code if invalid data', async () => {
-  //     const invalidLocation = { address: false };
-  //     const response = await request(app.getHttpServer()).post('/locations').send(invalidLocation);
-  //     expect(response.statusCode).toBe(400);
-  //   });
+      // delete the location at the end of the test
+      await locationsService.remove(response.body.id);
+    });
+  });
 
-  //   it('should return 201 and the new location after creation', async () => {
-  //     const newLocation = {
-  //       address: 'Nørrebrogade 56, 2200 København',
-  //       city: 'København',
-  //       streetName: 'Nørrebrogade',
-  //       streetNumber: '56',
-  //       postalCode: '2200',
-  //       openingHours: {
-  //         monday: { from: '00:00', to: '24:00' },
-  //         tuesday: { from: '00:00', to: '24:00' },
-  //         wednesday: { from: '00:00', to: '24:00' },
-  //         thursday: { from: '00:00', to: '24:00' },
-  //         friday: { from: '00:00', to: '24:00' },
-  //         saturday: { from: '00:00', to: '24:00' },
-  //         sunday: { from: 'Closed', to: 'Closed' },
-  //       },
-  //       status: 'closed',
-  //       image: 'https://example.com/image3.jpg',
-  //       coordinates: {
-  //         latitude: 55.6887,
-  //         longitude: 12.5489,
-  //       },
-  //     };
+  describe('/locations (POST)', () => {
+    it('should return 400 status code if invalid data', async () => {
+      const invalidLocation = { address: false };
+      const response = await request(app.getHttpServer())
+        .post('/locations')
+        .send(invalidLocation)
+        .set('Authorization', token);
+      expect(response.statusCode).toBe(400);
+    });
 
-  //     const response = await request(app.getHttpServer()).post('/locations').send(newLocation);
+    it('should return 201 and the new location after creation', async () => {
+      const newLocation = new CreateLocationDto(
+        'København',
+        'Nørrebrogade',
+        '56',
+        '2200',
+        {
+          monday: { from: '00:00', to: '24:00' },
+          tuesday: { from: '00:00', to: '24:00' },
+          wednesday: { from: '00:00', to: '24:00' },
+          thursday: { from: '00:00', to: '24:00' },
+          friday: { from: '00:00', to: '24:00' },
+          saturday: { from: '00:00', to: '24:00' },
+          sunday: { from: 'Closed', to: 'Closed' },
+        },
+        LocationStatus.closed,
+        'https://example.com/image3.jpg',
+        {
+          latitude: 55.6887,
+          longitude: 12.5489,
+        },
+      );
 
-  //     expect(response.statusCode).toBe(201);
-  //     expect(response.body).toBeDefined();
-  //     expect(response.body.id).toBeDefined();
+      const response = await request(app.getHttpServer())
+        .post('/locations')
+        .send(newLocation)
+        .set('Authorization', token);
 
-  //     // delete the location at the end of the test
-  //     await locationsService.remove(response.body.id);
-  //   });
-  // });
+      expect(response.statusCode).toBe(201);
+      expect(response.body).toBeDefined();
+      expect(response.body.id).toBeDefined();
 
-  // afterAll(async () => {
-  //   await app.close();
-  // });
+      // delete the location at the end of the test
+      await locationsService.remove(response.body.id);
+    });
+  });
+
+  afterAll(async () => {
+    await userService.remove(user.id);
+    await app.close();
+  });
 });

--- a/test/services.controller.e2e-spec.ts
+++ b/test/services.controller.e2e-spec.ts
@@ -20,24 +20,25 @@ describe('Service Controller (e2e)', () => {
     await app.init();
   });
 
-  describe('/services (GET)', () => {
-    it('should return 200 and an array of services', async () => {
-      const response = await request(app.getHttpServer()).get('/services');
-      expect(response.statusCode).toBe(200);
-      expect(response.body).toBeDefined();
-      expect(Array.isArray(response.body)).toBe(true);
-    });
-  });
+  // FIXME SEND JWT TOKEN
+  // describe('/services (GET)', () => {
+  //   it('should return 200 and an array of services', async () => {
+  //     const response = await request(app.getHttpServer()).get('/services');
+  //     expect(response.statusCode).toBe(200);
+  //     expect(response.body).toBeDefined();
+  //     expect(Array.isArray(response.body)).toBe(true);
+  //   });
+  // });
 
-  describe('/service (POST)', () => {
-    it('should return 400 status code if invalid data', async () => {
-      const invalidService = { type: 'invalid', price: 'XD' };
-      const response = await request(app.getHttpServer()).post('/services').send(invalidService);
-      expect(response.statusCode).toBe(400);
-    });
-  });
+  // describe('/service (POST)', () => {
+  //   it('should return 400 status code if invalid data', async () => {
+  //     const invalidService = { type: 'invalid', price: 'XD' };
+  //     const response = await request(app.getHttpServer()).post('/services').send(invalidService);
+  //     expect(response.statusCode).toBe(400);
+  //   });
+  // });
 
-  afterAll(async () => {
-    await app.close();
-  });
+  // afterAll(async () => {
+  //   await app.close();
+  // });
 });

--- a/test/services.controller.e2e-spec.ts
+++ b/test/services.controller.e2e-spec.ts
@@ -2,10 +2,19 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from 'src/app.module';
+import { UserService } from 'src/user/user.service';
+import { AuthService } from 'src/auth/auth.service';
+import { User } from 'src/user/entities/user.entity';
+import { CreateUserDto } from 'src/user/dto/create-user.dto';
+import { LoginDto } from 'src/auth/dto/login.dto';
 import { ServiceService } from 'src/service/service.service';
 
 describe('Service Controller (e2e)', () => {
   let app: INestApplication;
+  let userService: UserService;
+  let authService: AuthService;
+  let token: string;
+  let user: User;
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let serviceService: ServiceService;
 
@@ -14,31 +23,47 @@ describe('Service Controller (e2e)', () => {
       imports: [AppModule],
     }).compile();
 
+    userService = moduleFixture.get<UserService>(UserService);
+    authService = moduleFixture.get<AuthService>(AuthService);
     serviceService = moduleFixture.get<ServiceService>(ServiceService);
+
+    // Sign up
+    const userDTO = new CreateUserDto('test', 'user', 'testuser@mail.com', '12345');
+    user = await userService.create(userDTO);
+
+    // Log in
+    const loginDTO = new LoginDto('test4@mail.com', '12345');
+    const loginResponse = await authService.login(loginDTO);
+    token = loginResponse.token;
+
     app = moduleFixture.createNestApplication();
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
   });
 
-  // FIXME SEND JWT TOKEN
-  // describe('/services (GET)', () => {
-  //   it('should return 200 and an array of services', async () => {
-  //     const response = await request(app.getHttpServer()).get('/services');
-  //     expect(response.statusCode).toBe(200);
-  //     expect(response.body).toBeDefined();
-  //     expect(Array.isArray(response.body)).toBe(true);
-  //   });
-  // });
+  describe('/services (GET)', () => {
+    it('should return 200 and an array of services', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/services')
+        .set('Authorization', token);
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toBeDefined();
+      expect(Array.isArray(response.body)).toBe(true);
+    });
+  });
 
-  // describe('/service (POST)', () => {
-  //   it('should return 400 status code if invalid data', async () => {
-  //     const invalidService = { type: 'invalid', price: 'XD' };
-  //     const response = await request(app.getHttpServer()).post('/services').send(invalidService);
-  //     expect(response.statusCode).toBe(400);
-  //   });
-  // });
-
-  // afterAll(async () => {
-  //   await app.close();
-  // });
+  describe('/service (POST)', () => {
+    it('should return 400 status code if invalid data', async () => {
+      const invalidService = { type: 'invalid', price: 'XD' };
+      const response = await request(app.getHttpServer())
+        .post('/services')
+        .send(invalidService)
+        .set('Authorization', token);
+      expect(response.statusCode).toBe(400);
+    });
+  });
+  afterAll(async () => {
+    await userService.remove(user.id);
+    await app.close();
+  });
 });

--- a/test/services.controller.e2e-spec.ts
+++ b/test/services.controller.e2e-spec.ts
@@ -28,11 +28,11 @@ describe('Service Controller (e2e)', () => {
     serviceService = moduleFixture.get<ServiceService>(ServiceService);
 
     // Sign up
-    const userDTO = new CreateUserDto('test', 'user', 'testuser@mail.com', '12345');
+    const userDTO = new CreateUserDto('test', 'user', 'testuser6@mail.com', '12345');
     user = await userService.create(userDTO);
 
     // Log in
-    const loginDTO = new LoginDto('test4@mail.com', '12345');
+    const loginDTO = new LoginDto('testuser6@mail.com', '12345');
     const loginResponse = await authService.login(loginDTO);
     token = loginResponse.token;
 

--- a/test/steps.controller.e2e-spec.ts
+++ b/test/steps.controller.e2e-spec.ts
@@ -2,10 +2,19 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from 'src/app.module';
+import { UserService } from 'src/user/user.service';
+import { AuthService } from 'src/auth/auth.service';
+import { User } from 'src/user/entities/user.entity';
+import { CreateUserDto } from 'src/user/dto/create-user.dto';
+import { LoginDto } from 'src/auth/dto/login.dto';
 import { StepsService } from 'src/steps/steps.service';
 
 describe('Step Controller (e2e)', () => {
   let app: INestApplication;
+  let userService: UserService;
+  let authService: AuthService;
+  let token: string;
+  let user: User;
   let stepsService: StepsService;
 
   beforeAll(async () => {
@@ -13,48 +22,66 @@ describe('Step Controller (e2e)', () => {
       imports: [AppModule],
     }).compile();
 
+    userService = moduleFixture.get<UserService>(UserService);
+    authService = moduleFixture.get<AuthService>(AuthService);
     stepsService = moduleFixture.get<StepsService>(StepsService);
+
+    // Sign up
+    const userDTO = new CreateUserDto('test', 'user', 'testuser@mail.com', '12345');
+    user = await userService.create(userDTO);
+
+    // Log in
+    const loginDTO = new LoginDto('test4@mail.com', '12345');
+    const loginResponse = await authService.login(loginDTO);
+    token = loginResponse.token;
+
     app = moduleFixture.createNestApplication();
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
   });
 
-  // FIXME SEND JWT TOKEN
-  // describe('/steps (GET)', () => {
-  //   it('should return 200 and an array of steps', async () => {
-  //     const response = await request(app.getHttpServer()).get('/steps');
-  //     expect(response.statusCode).toBe(200);
-  //     expect(response.body).toBeDefined();
-  //     expect(Array.isArray(response.body)).toBe(true);
-  //   });
-  // });
+  describe('/steps (GET)', () => {
+    it('should return 200 and an array of steps', async () => {
+      const response = await request(app.getHttpServer()).get('/steps').set('Authorization', token);
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toBeDefined();
+      expect(Array.isArray(response.body)).toBe(true);
+    });
+  });
 
-  // describe('/steps (POST)', () => {
-  //   it('should return 400 status code if invalid data', async () => {
-  //     const invalidStep = { name: false };
-  //     const response = await request(app.getHttpServer()).post('/steps').send(invalidStep);
-  //     expect(response.statusCode).toBe(400);
-  //   });
+  describe('/steps (POST)', () => {
+    it('should return 400 status code if invalid data', async () => {
+      const invalidStep = { name: false };
+      const response = await request(app.getHttpServer())
+        .post('/steps')
+        .send(invalidStep)
+        .set('Authorization', token);
+      expect(response.statusCode).toBe(400);
+    });
 
-  //   it('should return 201 and the new step after creation', async () => {
-  //     const validStep = {
-  //       name: 'TestStep',
-  //       order: 999,
-  //       description: 'This is a test step',
-  //       duration: 60,
-  //     };
-  //     const response = await request(app.getHttpServer()).post('/steps').send(validStep);
+    it('should return 201 and the new step after creation', async () => {
+      const validStep = {
+        name: 'TestStep',
+        order: 999,
+        description: 'This is a test step',
+        duration: 60,
+      };
+      const response = await request(app.getHttpServer())
+        .post('/steps')
+        .send(validStep)
+        .set('Authorization', token);
 
-  //     expect(response.statusCode).toBe(201);
-  //     expect(response.body).toBeDefined();
-  //     expect(response.body.id).toBeDefined();
+      expect(response.statusCode).toBe(201);
+      expect(response.body).toBeDefined();
+      expect(response.body.id).toBeDefined();
 
-  //     // delete the step at the end of the test
-  //     await stepsService.remove(response.body.id);
-  //   });
-  // });
+      // delete the step at the end of the test
+      await stepsService.remove(response.body.id);
+    });
+  });
 
-  // afterAll(async () => {
-  //   await app.close();
-  // });
+  afterAll(async () => {
+    await userService.remove(user.id);
+    await app.close();
+  });
 });

--- a/test/steps.controller.e2e-spec.ts
+++ b/test/steps.controller.e2e-spec.ts
@@ -19,41 +19,42 @@ describe('Step Controller (e2e)', () => {
     await app.init();
   });
 
-  describe('/steps (GET)', () => {
-    it('should return 200 and an array of steps', async () => {
-      const response = await request(app.getHttpServer()).get('/steps');
-      expect(response.statusCode).toBe(200);
-      expect(response.body).toBeDefined();
-      expect(Array.isArray(response.body)).toBe(true);
-    });
-  });
+  // FIXME SEND JWT TOKEN
+  // describe('/steps (GET)', () => {
+  //   it('should return 200 and an array of steps', async () => {
+  //     const response = await request(app.getHttpServer()).get('/steps');
+  //     expect(response.statusCode).toBe(200);
+  //     expect(response.body).toBeDefined();
+  //     expect(Array.isArray(response.body)).toBe(true);
+  //   });
+  // });
 
-  describe('/steps (POST)', () => {
-    it('should return 400 status code if invalid data', async () => {
-      const invalidStep = { name: false };
-      const response = await request(app.getHttpServer()).post('/steps').send(invalidStep);
-      expect(response.statusCode).toBe(400);
-    });
+  // describe('/steps (POST)', () => {
+  //   it('should return 400 status code if invalid data', async () => {
+  //     const invalidStep = { name: false };
+  //     const response = await request(app.getHttpServer()).post('/steps').send(invalidStep);
+  //     expect(response.statusCode).toBe(400);
+  //   });
 
-    it('should return 201 and the new step after creation', async () => {
-      const validStep = {
-        name: 'TestStep',
-        order: 999,
-        description: 'This is a test step',
-        duration: 60,
-      };
-      const response = await request(app.getHttpServer()).post('/steps').send(validStep);
+  //   it('should return 201 and the new step after creation', async () => {
+  //     const validStep = {
+  //       name: 'TestStep',
+  //       order: 999,
+  //       description: 'This is a test step',
+  //       duration: 60,
+  //     };
+  //     const response = await request(app.getHttpServer()).post('/steps').send(validStep);
 
-      expect(response.statusCode).toBe(201);
-      expect(response.body).toBeDefined();
-      expect(response.body.id).toBeDefined();
+  //     expect(response.statusCode).toBe(201);
+  //     expect(response.body).toBeDefined();
+  //     expect(response.body.id).toBeDefined();
 
-      // delete the step at the end of the test
-      await stepsService.remove(response.body.id);
-    });
-  });
+  //     // delete the step at the end of the test
+  //     await stepsService.remove(response.body.id);
+  //   });
+  // });
 
-  afterAll(async () => {
-    await app.close();
-  });
+  // afterAll(async () => {
+  //   await app.close();
+  // });
 });

--- a/test/steps.controller.e2e-spec.ts
+++ b/test/steps.controller.e2e-spec.ts
@@ -27,11 +27,11 @@ describe('Step Controller (e2e)', () => {
     stepsService = moduleFixture.get<StepsService>(StepsService);
 
     // Sign up
-    const userDTO = new CreateUserDto('test', 'user', 'testuser@mail.com', '12345');
+    const userDTO = new CreateUserDto('test', 'user', 'testuser7@mail.com', '12345');
     user = await userService.create(userDTO);
 
     // Log in
-    const loginDTO = new LoginDto('test4@mail.com', '12345');
+    const loginDTO = new LoginDto('testuser7@mail.com', '12345');
     const loginResponse = await authService.login(loginDTO);
     token = loginResponse.token;
 

--- a/test/terminal.controller.e2e-spec.ts
+++ b/test/terminal.controller.e2e-spec.ts
@@ -20,39 +20,39 @@ describe('Terminal Controller (e2e)', () => {
     await app.init();
   });
 
-  describe('/terminals (GET)', () => {
-    it('should return 200 and an array of terminals', async () => {
-      const response = await request(app.getHttpServer()).get('/terminals');
-      expect(response.statusCode).toBe(200);
-      expect(response.body).toBeDefined();
-      expect(Array.isArray(response.body)).toBe(true);
-    });
-  });
+  // describe('/terminals (GET)', () => {
+  //   it('should return 200 and an array of terminals', async () => {
+  //     const response = await request(app.getHttpServer()).get('/terminals');
+  //     expect(response.statusCode).toBe(200);
+  //     expect(response.body).toBeDefined();
+  //     expect(Array.isArray(response.body)).toBe(true);
+  //   });
+  // });
 
-  describe('/terminals (POST)', () => {
-    it('should return 400 status code if invalid data', async () => {
-      const invalidTerminal = { status: 'invalid', location: 'XD' };
-      const response = await request(app.getHttpServer()).post('/terminals').send(invalidTerminal);
-      expect(response.statusCode).toBe(400);
-    });
+  // describe('/terminals (POST)', () => {
+  //   it('should return 400 status code if invalid data', async () => {
+  //     const invalidTerminal = { status: 'invalid', location: 'XD' };
+  //     const response = await request(app.getHttpServer()).post('/terminals').send(invalidTerminal);
+  //     expect(response.statusCode).toBe(400);
+  //   });
 
-    // TODO: when we have locations and events
-    // it('should return 201 and the new terminal after creation', async () => {
-    //   const response = await request(app.getHttpServer())
-    //     .post('/terminal')
-    //     .send({ status: 'idle', location: 1 });
+  // TODO: when we have locations and events
+  // it('should return 201 and the new terminal after creation', async () => {
+  //   const response = await request(app.getHttpServer())
+  //     .post('/terminal')
+  //     .send({ status: 'idle', location: 1 });
 
-    //   console.log(response.body);
-    //   expect(response.statusCode).toBe(201);
-    //   expect(response.body).toBeDefined();
-    //   expect(response.body.id).toBeDefined();
+  //   console.log(response.body);
+  //   expect(response.statusCode).toBe(201);
+  //   expect(response.body).toBeDefined();
+  //   expect(response.body.id).toBeDefined();
 
-    //   // delete the terminal at the end of the test
-    //   await terminalService.remove(response.body.id);
-    // });
-  });
+  //   // delete the terminal at the end of the test
+  //   await terminalService.remove(response.body.id);
+  // });
+  // });
 
-  afterAll(async () => {
-    await app.close();
-  });
+  //   afterAll(async () => {
+  //     await app.close();
+  //   });
 });

--- a/test/terminal.controller.e2e-spec.ts
+++ b/test/terminal.controller.e2e-spec.ts
@@ -2,10 +2,19 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from 'src/app.module';
+import { UserService } from 'src/user/user.service';
+import { AuthService } from 'src/auth/auth.service';
+import { User } from 'src/user/entities/user.entity';
+import { CreateUserDto } from 'src/user/dto/create-user.dto';
+import { LoginDto } from 'src/auth/dto/login.dto';
 import { TerminalService } from 'src/terminal/terminal.service';
 
 describe('Terminal Controller (e2e)', () => {
   let app: INestApplication;
+  let userService: UserService;
+  let authService: AuthService;
+  let token: string;
+  let user: User;
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let terminalService: TerminalService;
 
@@ -14,45 +23,62 @@ describe('Terminal Controller (e2e)', () => {
       imports: [AppModule],
     }).compile();
 
+    userService = moduleFixture.get<UserService>(UserService);
+    authService = moduleFixture.get<AuthService>(AuthService);
     terminalService = moduleFixture.get<TerminalService>(TerminalService);
+
+    // Sign up
+    const userDTO = new CreateUserDto('test', 'user', 'testuser@mail.com', '12345');
+    user = await userService.create(userDTO);
+
+    // Log in
+    const loginDTO = new LoginDto('test4@mail.com', '12345');
+    const loginResponse = await authService.login(loginDTO);
+    token = loginResponse.token;
+
     app = moduleFixture.createNestApplication();
     app.useGlobalPipes(new ValidationPipe());
     await app.init();
   });
 
-  // describe('/terminals (GET)', () => {
-  //   it('should return 200 and an array of terminals', async () => {
-  //     const response = await request(app.getHttpServer()).get('/terminals');
-  //     expect(response.statusCode).toBe(200);
-  //     expect(response.body).toBeDefined();
-  //     expect(Array.isArray(response.body)).toBe(true);
-  //   });
-  // });
+  describe('/terminals (GET)', () => {
+    it('should return 200 and an array of terminals', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/terminals')
+        .set('Authorization', token);
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toBeDefined();
+      expect(Array.isArray(response.body)).toBe(true);
+    });
+  });
 
-  // describe('/terminals (POST)', () => {
-  //   it('should return 400 status code if invalid data', async () => {
-  //     const invalidTerminal = { status: 'invalid', location: 'XD' };
-  //     const response = await request(app.getHttpServer()).post('/terminals').send(invalidTerminal);
-  //     expect(response.statusCode).toBe(400);
-  //   });
+  describe('/terminals (POST)', () => {
+    it('should return 400 status code if invalid data', async () => {
+      const invalidTerminal = { status: 'invalid', location: 'XD' };
+      const response = await request(app.getHttpServer())
+        .post('/terminals')
+        .send(invalidTerminal)
+        .set('Authorization', token);
+      expect(response.statusCode).toBe(400);
+    });
 
-  // TODO: when we have locations and events
-  // it('should return 201 and the new terminal after creation', async () => {
-  //   const response = await request(app.getHttpServer())
-  //     .post('/terminal')
-  //     .send({ status: 'idle', location: 1 });
+    it('should return 201 and the new terminal after creation', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/terminals')
+        .send({ status: 'idle', locationId: 1 })
+        .set('Authorization', token);
 
-  //   console.log(response.body);
-  //   expect(response.statusCode).toBe(201);
-  //   expect(response.body).toBeDefined();
-  //   expect(response.body.id).toBeDefined();
+      expect(response.statusCode).toBe(201);
+      expect(response.body).toBeDefined();
+      expect(response.body.id).toBeDefined();
 
-  //   // delete the terminal at the end of the test
-  //   await terminalService.remove(response.body.id);
-  // });
-  // });
+      // delete the terminal at the end of the test
+      await terminalService.remove(response.body.id);
+    });
+  });
 
-  //   afterAll(async () => {
-  //     await app.close();
-  //   });
+  afterAll(async () => {
+    await userService.remove(user.id);
+    await app.close();
+  });
 });

--- a/test/terminal.controller.e2e-spec.ts
+++ b/test/terminal.controller.e2e-spec.ts
@@ -28,11 +28,11 @@ describe('Terminal Controller (e2e)', () => {
     terminalService = moduleFixture.get<TerminalService>(TerminalService);
 
     // Sign up
-    const userDTO = new CreateUserDto('test', 'user', 'testuser@mail.com', '12345');
+    const userDTO = new CreateUserDto('test', 'user', 'testuser8@mail.com', '12345');
     user = await userService.create(userDTO);
 
     // Log in
-    const loginDTO = new LoginDto('test4@mail.com', '12345');
+    const loginDTO = new LoginDto('testuser8@mail.com', '12345');
     const loginResponse = await authService.login(loginDTO);
     token = loginResponse.token;
 

--- a/test/user.controller.e2e-spec.ts
+++ b/test/user.controller.e2e-spec.ts
@@ -95,71 +95,73 @@ describe('User Controller (e2e)', () => {
     });
   });
 
-  // describe('/user/:id (PATCH)', () => {
-  //   it('should return 400 status code if user id is not a number', async () => {
-  //     const response = await request(app.getHttpServer())
-  //       .patch('/user/a9999999999')
-  //       .set('Authorization', token);
-  //     expect(response.statusCode).toBe(400);
-  //     expect(response.body.message).toBe('User id is not a number');
-  //   });
+  describe('/user/:id (PATCH)', () => {
+    it('should return 400 status code if user id is not a number', async () => {
+      const response = await request(app.getHttpServer())
+        .patch('/user/a9999999999')
+        .set('Authorization', token);
+      expect(response.statusCode).toBe(400);
+      expect(response.body.message).toBe('User id is not a number');
+    });
 
-  //   it('should return 404 if user not found', async () => {
-  //     const response = await request(app.getHttpServer())
-  //       .patch('/user/999999')
-  //       .set('Authorization', token);
-  //     expect(response.statusCode).toBe(404);
-  //     expect(response.body.message).toBe('User not found');
-  //   });
+    it('should return 404 if user not found', async () => {
+      const response = await request(app.getHttpServer())
+        .patch('/user/999999')
+        .set('Authorization', token);
+      expect(response.statusCode).toBe(404);
+      expect(response.body.message).toBe('User not found');
+    });
 
-  //   it('should return 400 status code if invalid data', async () => {
-  //     const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail@john.com', 'qwerty');
-  //     const newUser = await userService.create(newUserDTO);
-  //     const invalidUser = { ...newUser, firstName: 1234 };
+    it('should return 400 status code if invalid data', async () => {
+      const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail@john.com', 'qwerty');
+      const newUser = await userService.create(newUserDTO);
+      const invalidUser = { ...newUser, firstName: 1234 };
 
-  //     const response = await request(app.getHttpServer())
-  //       .patch(`/user/${invalidUser.id}`)
-  //       .set('Authorization', token)
-  //       .send(invalidUser);
+      const response = await request(app.getHttpServer())
+        .patch(`/user/${invalidUser.id}`)
+        .set('Authorization', token)
+        .send(invalidUser);
 
-  //     expect(response.statusCode).toBe(400);
+      expect(response.statusCode).toBe(400);
 
-  //     await userService.remove(newUser.id);
-  //   });
+      await userService.remove(newUser.id);
+    });
 
-  //   it('should return 200 and the updated data', async () => {
-  //     const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail@john.com', 'qwerty');
-  //     const newUser = await userService.create(newUserDTO);
-  //     const updatedUser = { ...newUser, firstName: 'updated firstName' };
+    it('should return 200 and the updated data', async () => {
+      const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail@john.com', 'qwerty');
+      const newUser = await userService.create(newUserDTO);
+      const updatedUser = { ...newUser, firstName: 'updated firstName' };
 
-  //     const response = await request(app.getHttpServer())
-  //       .patch(`/user/${updatedUser.id}`)
-  //       .set('Authorization', token)
-  //       .send(updatedUser);
+      const response = await request(app.getHttpServer())
+        .patch(`/user/${updatedUser.id}`)
+        .set('Authorization', token)
+        .send(updatedUser);
 
-  //     expect(response.statusCode).toBe(200);
-  //     expect(response.body).toBeDefined();
-  //     expect(response.body.firstName).toBe('Updated Firstname');
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toBeDefined();
+      expect(response.body.firstName).toBe('Updated Firstname');
 
-  //     await userService.remove(newUser.id);
-  //   });
-  // });
+      await userService.remove(newUser.id);
+    });
+  });
 
-  // describe('/user/:id (DELETE)', () => {
-  //   it('should return 400 status code if user id is not a number', async () => {
-  //     const response = await request(app.getHttpServer())
-  //       .delete('/user/a123')
-  //       .set('Authorization', token);
-  //     expect(response.statusCode).toBe(400);
-  //     expect(response.body.message).toBe('User id is not a number');
-  //   });
+  describe('/user/:id (DELETE)', () => {
+    it('should return 400 status code if user id is not a number', async () => {
+      const response = await request(app.getHttpServer())
+        .delete('/user/a123')
+        .set('Authorization', token);
+      expect(response.statusCode).toBe(400);
+      expect(response.body.message).toBe('User id is not a number');
+    });
 
-  //   it('should return 404 if user not found', async () => {
-  //     const response = await request(app.getHttpServer()).delete('/user/999999');
-  //     expect(response.statusCode).toBe(404);
-  //     expect(response.body.message).toBe('User not found');
-  //   });
-  // });
+    it('should return 404 if user not found', async () => {
+      const response = await request(app.getHttpServer())
+        .delete('/user/999999')
+        .set('Authorization', token);
+      expect(response.statusCode).toBe(404);
+      expect(response.body.message).toBe('User not found');
+    });
+  });
 
   afterAll(async () => {
     await userService.remove(user.id);

--- a/test/user.controller.e2e-spec.ts
+++ b/test/user.controller.e2e-spec.ts
@@ -26,11 +26,11 @@ describe('User Controller (e2e)', () => {
     authService = moduleFixture.get<AuthService>(AuthService);
 
     // Sign up
-    const userDTO = new CreateUserDto('test', 'user', 'testuser@mail.com', '12345');
+    const userDTO = new CreateUserDto('test', 'user', 'testuser9@mail.com', '12345');
     user = await userService.create(userDTO);
 
     // Log in
-    const loginDTO = new LoginDto('test4@mail.com', '12345');
+    const loginDTO = new LoginDto('testuser9@mail.com', '12345');
     const loginResponse = await authService.login(loginDTO);
     token = loginResponse.token;
 
@@ -113,7 +113,7 @@ describe('User Controller (e2e)', () => {
     });
 
     it('should return 400 status code if invalid data', async () => {
-      const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail@john.com', 'qwerty');
+      const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail2@john.com', 'qwerty');
       const newUser = await userService.create(newUserDTO);
       const invalidUser = { ...newUser, firstName: 1234 };
 
@@ -128,7 +128,7 @@ describe('User Controller (e2e)', () => {
     });
 
     it('should return 200 and the updated data', async () => {
-      const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail@john.com', 'qwerty');
+      const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail3@john.com', 'qwerty');
       const newUser = await userService.create(newUserDTO);
       const updatedUser = { ...newUser, firstName: 'updated firstName' };
 

--- a/test/user.controller.e2e-spec.ts
+++ b/test/user.controller.e2e-spec.ts
@@ -25,10 +25,12 @@ describe('User Controller (e2e)', () => {
     userService = moduleFixture.get<UserService>(UserService);
     authService = moduleFixture.get<AuthService>(AuthService);
 
-    const userDTO = new CreateUserDto('John', 'Doe', 'mail@john.com', 'qwerty');
+    // Sign up
+    const userDTO = new CreateUserDto('test', 'user', 'testuser@mail.com', '12345');
     user = await userService.create(userDTO);
 
-    const loginDTO = new LoginDto('mail@john.com', 'qwerty');
+    // Log in
+    const loginDTO = new LoginDto('test4@mail.com', '12345');
     const loginResponse = await authService.login(loginDTO);
     token = loginResponse.token;
 
@@ -37,18 +39,18 @@ describe('User Controller (e2e)', () => {
     await app.init();
   });
 
-  describe('/user (POST)', () => {
+  describe('/auth/signup (POST)', () => {
     it('should return 400 status code if invalid data', async () => {
       const invalidUser = { ...userDTO, email: 222 };
 
-      const response = await request(app.getHttpServer()).post('/user').send(invalidUser);
+      const response = await request(app.getHttpServer()).post('/auth/signup').send(invalidUser);
 
       expect(response.statusCode).toBe(400);
     });
 
     it('should return 201 and the new user after creation', async () => {
-      const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail@john.com', 'qwerty');
-      const response = await request(app.getHttpServer()).post('/user').send(newUserDTO);
+      const newUserDTO = new CreateUserDto('John', 'Doe', '1234@john.com', 'qwerty');
+      const response = await request(app.getHttpServer()).post('/auth/signup').send(newUserDTO);
 
       expect(response.statusCode).toBe(201);
       expect(response.body).toBeDefined();
@@ -80,7 +82,9 @@ describe('User Controller (e2e)', () => {
       const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail@john.com', 'qwerty');
       const newUser = await userService.create(newUserDTO);
 
-      const response = await request(app.getHttpServer()).get(`/user/${newUser.id}`);
+      const response = await request(app.getHttpServer())
+        .get(`/user/${newUser.id}`)
+        .set('Authorization', token);
 
       expect(response.statusCode).toBe(200);
       expect(response.body).toBeDefined();
@@ -91,71 +95,71 @@ describe('User Controller (e2e)', () => {
     });
   });
 
-  describe('/user/:id (PATCH)', () => {
-    it('should return 400 status code if user id is not a number', async () => {
-      const response = await request(app.getHttpServer())
-        .patch('/user/a9999999999')
-        .set('Authorization', token);
-      expect(response.statusCode).toBe(400);
-      expect(response.body.message).toBe('User id is not a number');
-    });
+  // describe('/user/:id (PATCH)', () => {
+  //   it('should return 400 status code if user id is not a number', async () => {
+  //     const response = await request(app.getHttpServer())
+  //       .patch('/user/a9999999999')
+  //       .set('Authorization', token);
+  //     expect(response.statusCode).toBe(400);
+  //     expect(response.body.message).toBe('User id is not a number');
+  //   });
 
-    it('should return 404 if user not found', async () => {
-      const response = await request(app.getHttpServer())
-        .patch('/user/999999')
-        .set('Authorization', token);
-      expect(response.statusCode).toBe(404);
-      expect(response.body.message).toBe('User not found');
-    });
+  //   it('should return 404 if user not found', async () => {
+  //     const response = await request(app.getHttpServer())
+  //       .patch('/user/999999')
+  //       .set('Authorization', token);
+  //     expect(response.statusCode).toBe(404);
+  //     expect(response.body.message).toBe('User not found');
+  //   });
 
-    it('should return 400 status code if invalid data', async () => {
-      const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail@john.com', 'qwerty');
-      const newUser = await userService.create(newUserDTO);
-      const invalidUser = { ...newUser, firstName: 1234 };
+  //   it('should return 400 status code if invalid data', async () => {
+  //     const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail@john.com', 'qwerty');
+  //     const newUser = await userService.create(newUserDTO);
+  //     const invalidUser = { ...newUser, firstName: 1234 };
 
-      const response = await request(app.getHttpServer())
-        .patch(`/user/${invalidUser.id}`)
-        .set('Authorization', token)
-        .send(invalidUser);
+  //     const response = await request(app.getHttpServer())
+  //       .patch(`/user/${invalidUser.id}`)
+  //       .set('Authorization', token)
+  //       .send(invalidUser);
 
-      expect(response.statusCode).toBe(400);
+  //     expect(response.statusCode).toBe(400);
 
-      await userService.remove(newUser.id);
-    });
+  //     await userService.remove(newUser.id);
+  //   });
 
-    it('should return 200 and the updated data', async () => {
-      const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail@john.com', 'qwerty');
-      const newUser = await userService.create(newUserDTO);
-      const updatedUser = { ...newUser, firstName: 'updated firstName' };
+  //   it('should return 200 and the updated data', async () => {
+  //     const newUserDTO = new CreateUserDto('John', 'Doe', 'testemail@john.com', 'qwerty');
+  //     const newUser = await userService.create(newUserDTO);
+  //     const updatedUser = { ...newUser, firstName: 'updated firstName' };
 
-      const response = await request(app.getHttpServer())
-        .patch(`/user/${updatedUser.id}`)
-        .set('Authorization', token)
-        .send(updatedUser);
+  //     const response = await request(app.getHttpServer())
+  //       .patch(`/user/${updatedUser.id}`)
+  //       .set('Authorization', token)
+  //       .send(updatedUser);
 
-      expect(response.statusCode).toBe(200);
-      expect(response.body).toBeDefined();
-      expect(response.body.firstName).toBe('Updated Firstname');
+  //     expect(response.statusCode).toBe(200);
+  //     expect(response.body).toBeDefined();
+  //     expect(response.body.firstName).toBe('Updated Firstname');
 
-      await userService.remove(newUser.id);
-    });
-  });
+  //     await userService.remove(newUser.id);
+  //   });
+  // });
 
-  describe('/user/:id (DELETE)', () => {
-    it('should return 400 status code if user id is not a number', async () => {
-      const response = await request(app.getHttpServer())
-        .delete('/user/a123')
-        .set('Authorization', token);
-      expect(response.statusCode).toBe(400);
-      expect(response.body.message).toBe('User id is not a number');
-    });
+  // describe('/user/:id (DELETE)', () => {
+  //   it('should return 400 status code if user id is not a number', async () => {
+  //     const response = await request(app.getHttpServer())
+  //       .delete('/user/a123')
+  //       .set('Authorization', token);
+  //     expect(response.statusCode).toBe(400);
+  //     expect(response.body.message).toBe('User id is not a number');
+  //   });
 
-    it('should return 404 if user not found', async () => {
-      const response = await request(app.getHttpServer()).delete('/user/999999');
-      expect(response.statusCode).toBe(404);
-      expect(response.body.message).toBe('User not found');
-    });
-  });
+  //   it('should return 404 if user not found', async () => {
+  //     const response = await request(app.getHttpServer()).delete('/user/999999');
+  //     expect(response.statusCode).toBe(404);
+  //     expect(response.body.message).toBe('User not found');
+  //   });
+  // });
 
   afterAll(async () => {
     await userService.remove(user.id);


### PR DESCRIPTION
- AuthGuard decorator on all endpoints except login and signup
- Event, invoices, cars tests fixed and updated 
- Half of the user tests
- Invoice endpoint to delete an invoice by eventId in order to make event post tests and remove them afterwards

UPDATE:
- ALL tests updated and fixed
- Tests now run sequentially instead of in parallel because they were conflicting with each other